### PR TITLE
Fix GPR example

### DIFF
--- a/examples/GPR/main.jl
+++ b/examples/GPR/main.jl
@@ -4,9 +4,10 @@ import NPZ
 import PyPlot
 const plt = PyPlot
 
-include(joinpath("..","..","src","GPR.jl"))
+using CalibrateEmulateSample.GPR
 
-const gpr_data = NPZ.npzread(joinpath("..","..","test","GPR","data","data_points.npy"))
+const data_dir = joinpath(@__DIR__,"..","..","test","GPR","data")
+const gpr_data = NPZ.npzread(joinpath(data_dir,"data_points.npy"))
 
 ################################################################################
 # main section #################################################################


### PR DESCRIPTION
 - Changes the GPR example from `include` to `using` of `GPR.jl` (since depends on Utilities).
 - Fixes directory to include `@__DIR__` so that this file can be more flexibly included (e.g., in `GPR/` or `CalibrateEmulateSample.jl/`)

Closes #29 